### PR TITLE
Switch to :os.timestamp instead of :erlang.timestamp

### DIFF
--- a/lib/conn_logger.ex
+++ b/lib/conn_logger.ex
@@ -40,7 +40,7 @@ defmodule Ewebmachine.Log do
     if conn.private[:machine_debug] do
       conn
       |> Conn.put_private(:machine_log,id)
-      |> Conn.put_private(:machine_init_at,:erlang.timestamp)
+      |> Conn.put_private(:machine_init_at,:os.timestamp)
       |> Conn.put_private(:machine_decisions,[])
       |> Conn.put_private(:machine_calls,[])
     else conn end


### PR DESCRIPTION
For some reason, on my Erlang/OTP 17.4 packaged provided by Fedora Workstation 22, the `:erlang.timestamp/0` BIF is _not_ available.

This one liner switches to the :os.timestamp function. I'm relatively new to Elixir/Erlang, so this may not be 100% correct, but I've had zero success digging for reasons the currently used BIF would be missing.

Thoughts?
